### PR TITLE
Laravel5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   "require": {
     "illuminate/database": "~5",
     "illuminate/cache": "~5",
-    "illuminate/support": "~5"
+    "illuminate/support": "~5",
+    "laravel/framework": "~5.8.0 | ~6.0",
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "illuminate/database": "~5",
     "illuminate/cache": "~5",
     "illuminate/support": "~5",
-    "laravel/framework": "~5.8.0 | ~6.0",
+    "laravel/framework": "~5.8.0 | ~6.0"
   }
 }

--- a/src/Cacheable.php
+++ b/src/Cacheable.php
@@ -39,10 +39,10 @@ trait Cacheable
     public function getCacheLength()
     {
         if (isset($this->cacheLength)) {
-            return $this->cacheLength;
+            return $this->cacheLength * 60;
         }
 
-        return 30;
+        return 30 * 60;
     }
 
     /**


### PR DESCRIPTION
Laravel 5.8+ specifies the cache time in seconds not minutes so the default (and specified overrides) are being applied as a fraction of the expected time (i.e. everything is currently only cached for 30 seconds!).

As the easiest solution, this patch simply multiplies all provided values by 60 to provide seconds as now required. (i.e. users still only specify minutes).

Also (hopefully) added a composer constraint so lower Laravel versions do not end up with values expressed in seconds!